### PR TITLE
3.1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,13 +154,18 @@ jobs:
           cd webui && pnpm build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: webui/dist
 
   build-docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
     needs: [build-webui, version-info]
     steps:
       - name: Checkout
@@ -185,7 +190,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            estrellaxd/auto_bangumi
+            jumploop/auto_bangumi
             ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=${{ needs.version-info.outputs.version }}
@@ -197,7 +202,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            estrellaxd/auto_bangumi
+            jumploop/auto_bangumi
             ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=${{ needs.version-info.outputs.version }}
@@ -216,10 +221,10 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.ACCESS_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: backend/src/dist
@@ -230,7 +235,7 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.output.name }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: True
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -243,7 +248,7 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.output.name }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}
@@ -256,9 +261,9 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.output.name }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: false
-          tags: estrellaxd/auto_bangumi:test
+          tags: jumploop/auto_bangumi:test
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 
@@ -274,7 +279,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifact webui
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: webui/dist
@@ -284,7 +289,7 @@ jobs:
           cd webui && ls -al && tree && zip -r dist.zip dist
 
       - name: Download artifact app
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: backend/src/dist


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新构建工作流程以使用 jumploop docker 仓库，更新 github actions，并移除对 arm/v7 平台的支持。

构建：
- 更新 Docker 镜像仓库为 jumploop/auto_bangumi。
- 移除对 arm/v7 平台的支持。
- 更新 github actions 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Updates the build workflow to use the jumploop docker repository, updates github actions, and removes support for the arm/v7 platform.

Build:
- Updates the docker image repository to jumploop/auto_bangumi.
- Removes support for the arm/v7 platform.
- Updates github actions versions.

</details>